### PR TITLE
Fix for scheduled task class error

### DIFF
--- a/Sources/Quiz/Integration.php
+++ b/Sources/Quiz/Integration.php
@@ -9,7 +9,8 @@ class Integration
 {
 	public static function init()
 	{
-		Integration::setVersion();
+		self::setVersion();
+		self::loadScheduledClass();
 
 		add_integration_function('integrate_autoload', __CLASS__ . '::autoload', false);
 		add_integration_function('integrate_admin_areas', __CLASS__ . '::admin_areas', false);
@@ -42,6 +43,16 @@ class Integration
 			'SMFQuiz_99to100' => 'WOW - You are simply amazing. That is a Perfect Score! Did you Google those answers?',
 		];
 		$modSettings = array_merge($defaults, $modSettings);
+	}
+
+	public static function loadScheduledClass()
+	{
+		global $sourcedir;
+
+		// Ensure the task class is available
+		if (!class_exists(__NAMESPACE__  . '\Tasks\Scheduled')) {
+			require_once($sourcedir . '/' . __NAMESPACE__  . '/Tasks/Scheduled.php');
+		}
 	}
 
 	public static function autoload(&$classMap)


### PR DESCRIPTION
- adds required file for the SMF-Quiz scheduled task
- uses class constants 

This was on a fresh SMF installation without any other mods installed.
I had to do the same thing to the ST-Shop mod.

Your initialize object is being called by  by the pre_load hook which  comes before SMF's spl_autoload_register() function call in SMF's main index file. The cron which runs the scheduled tasks seems to complain about the missing class even though you intended it to be loaded by the autoload hook. Ensuring the Quiz task is loaded before the autoload fixes the problem.
  
This is the error message for reference:
> PHP Fatal error:  Uncaught Error: Class "Quiz\Tasks\Scheduled" not found in .\Sources\Subs.php:5978
Stack trace:
#0 .\Sources\ScheduledTasks.php(112): call_helper('Quiz\\Tasks\\Sche...', true)
#1 .\cron.php(150): AutoTask()
#2 {main}
  thrown in .\Sources\Subs.php on line 5978